### PR TITLE
recompilling Schemas after uninstalling the app.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@ install:
 uninstall:
 	rm /usr/bin/indicator-netspeed
 	rm /usr/share/glib-2.0/schemas/indicator-netspeed.gschema.xml
-
+	glib-compile-schemas /usr/share/glib-2.0/schemas/


### PR DESCRIPTION
even after executing 'sudo make uninstall', if I run the binary created by 'make' it runs successfully though there should be no compiled schemas.
